### PR TITLE
link: builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "scripts": {
-    "clean": "rm ./lib/*",
-    "prepare": "npm run build",
+    "clean": "rm -r ./lib",
+    "prepare": "npm run build && cp -r ./src/proto ./lib",
     "build": "tsc",
     "lint": "tslint --project \"./tsconfig.json\"",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "scripts": {
+    "clean": "rm ./lib/*",
     "prepare": "npm run build",
     "build": "tsc",
     "lint": "tslint --project \"./tsconfig.json\"",

--- a/src/link.spec.ts
+++ b/src/link.spec.ts
@@ -1,11 +1,26 @@
-import { linkVersion } from "./link";
-import { Link } from "./proto/chainscript_pb";
+import { Link } from "./link";
+import { Link as PbLink, LinkMeta as PbLinkMeta } from "./proto/chainscript_pb";
 
 describe("link", () => {
-  it("version", () => {
-    const link = new Link();
-    link.setVersion("0.42.0");
+  describe("process", () => {
+    it("throws if meta is missing", () => {
+      const link = new Link(new PbLink());
+      expect(() => link.process()).toThrowError("link meta is missing");
+    });
 
-    expect(linkVersion(link)).toEqual("0.42.0");
+    it("throws if process is missing", () => {
+      const pbLink = new PbLink();
+      pbLink.setMeta(new PbLinkMeta());
+
+      const link = new Link(pbLink);
+      expect(() => link.process()).toThrowError("link process is missing");
+    });
+  });
+
+  describe("map id", () => {
+    it("throws if meta is missing", () => {
+      const link = new Link(new PbLink());
+      expect(() => link.mapId()).toThrowError("link meta is missing");
+    });
   });
 });

--- a/src/link.ts
+++ b/src/link.ts
@@ -1,5 +1,39 @@
-import { Link } from "./proto/chainscript_pb";
+import { Link as LinkProto } from "./proto/chainscript_pb";
 
-export function linkVersion(link: Link): string {
-  return link.getVersion();
+export class Link {
+  private link: LinkProto;
+
+  constructor(link: LinkProto) {
+    this.link = link;
+  }
+
+  /** @returns the link version. */
+  public version(): string {
+    return this.link.getVersion();
+  }
+
+  /** @returns the link's map id. */
+  public mapId(): string {
+    const meta = this.link.getMeta();
+    if (!meta) {
+      throw new TypeError("link meta is missing");
+    }
+
+    return meta.getMapId();
+  }
+
+  /** @returns the link's process name. */
+  public process(): string {
+    const meta = this.link.getMeta();
+    if (!meta) {
+      throw new TypeError("link meta is missing");
+    }
+
+    const process = meta.getProcess();
+    if (!process) {
+      throw new TypeError("link process is missing");
+    }
+
+    return process.getName();
+  }
 }

--- a/src/link.ts
+++ b/src/link.ts
@@ -1,9 +1,9 @@
-import { Link as LinkProto } from "./proto/chainscript_pb";
+import { Link as PbLink } from "./proto/chainscript_pb";
 
 export class Link {
-  private link: LinkProto;
+  private link: PbLink;
 
-  constructor(link: LinkProto) {
+  constructor(link: PbLink) {
     this.link = link;
   }
 

--- a/src/link_builder.spec.ts
+++ b/src/link_builder.spec.ts
@@ -1,0 +1,26 @@
+import { LinkBuilder } from "./link_builder";
+
+describe("link builder", () => {
+  it("sets the link version", () => {
+    const link = new LinkBuilder("p", "m").build();
+    expect(link.version()).toEqual("1.0.0");
+  });
+
+  it("throws if process is missing", () => {
+    expect(() => new LinkBuilder("", "m")).toThrowError("process is missing");
+  });
+
+  it("sets the process name", () => {
+    const link = new LinkBuilder("p", "m").build();
+    expect(link.process()).toEqual("p");
+  });
+
+  it("throws if map id is missing", () => {
+    expect(() => new LinkBuilder("p", "")).toThrowError("map id is missing");
+  });
+
+  it("sets the map id", () => {
+    const link = new LinkBuilder("p", "m").build();
+    expect(link.mapId()).toEqual("m");
+  });
+});

--- a/src/link_builder.ts
+++ b/src/link_builder.ts
@@ -1,0 +1,62 @@
+import { Link } from "./link";
+import {
+  Link as PbLink,
+  LinkMeta as PbLinkMeta,
+  Process as PbProcess
+} from "./proto/chainscript_pb";
+
+/**
+ * LinkVersion_1_0_0 is the first version of the link encoding.
+ * In that version we encode interfaces (link.data and link.meta.data) with
+ * canonical JSON and hash the protobuf-encoded link bytes with SHA-256.
+ */
+const LINK_VERSION_1_0_0 = "1.0.0";
+/** The current link version. */
+const LINK_VERSION = LINK_VERSION_1_0_0;
+
+/**
+ * ILinkBuilder makes it easy to create links that adhere to the ChainScript
+ * spec.
+ * It provides valid default values for required fields and allows the user
+ * to set fields to valid values.
+ */
+export interface ILinkBuilder {
+  /** build the link. */
+  build(): Link;
+}
+
+/**
+ * LinkBuilder makes it easy to create links that adhere to the ChainScript
+ * spec.
+ * It provides valid default values for required fields and allows the user
+ * to set fields to valid values.
+ */
+export class LinkBuilder implements ILinkBuilder {
+  private link: PbLink;
+
+  constructor(process: string, mapId: string) {
+    this.link = new PbLink();
+    this.link.setVersion(LINK_VERSION);
+
+    if (!process) {
+      throw new TypeError("process is missing");
+    }
+
+    if (!mapId) {
+      throw new TypeError("map id is missing");
+    }
+
+    const proc = new PbProcess();
+    proc.setName(process);
+
+    const meta = new PbLinkMeta();
+    meta.setMapId(mapId);
+    meta.setProcess(proc);
+
+    this.link.setMeta(meta);
+  }
+
+  public build(): Link {
+    return new Link(this.link);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,5 +53,6 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["tslint:recommended"]
+  "extends": ["tslint:recommended"],
+  "rules": {
+    "trailing-comma": false
+  }
 }


### PR DESCRIPTION
The very beginning of the link builder.
Since we want to enforce some data validation / schema I think we can't directly expose the link object generated by protobuf. We need to wrap it in our own Link class and provide getters/setters only for relevant parts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-chainscript/3)
<!-- Reviewable:end -->
