### PR TITLE
segment: add references and evidences

### DIFF
--- a/src/evidence.spec.ts
+++ b/src/evidence.spec.ts
@@ -1,0 +1,35 @@
+import {
+  ErrMissingBackend,
+  ErrMissingProof,
+  ErrMissingProvider,
+  ErrMissingVersion,
+  Evidence
+} from "./evidence";
+
+describe("evidence", () => {
+  const proofData = Uint8Array.from([42]);
+
+  it("rejects missing version", () => {
+    expect(
+      () => new Evidence("", "bitcoin", "mainnet", proofData)
+    ).toThrowError(ErrMissingVersion);
+  });
+
+  it("rejects missing backend", () => {
+    expect(() => new Evidence("0.1.0", "", "mainnet", proofData)).toThrowError(
+      ErrMissingBackend
+    );
+  });
+
+  it("rejects missing provider", () => {
+    expect(() => new Evidence("0.1.0", "bitcoin", "", proofData)).toThrowError(
+      ErrMissingProvider
+    );
+  });
+
+  it("rejects missing proof", () => {
+    expect(
+      () => new Evidence("0.1.0", "bitcoin", "mainnet", new Uint8Array(0))
+    ).toThrowError(ErrMissingProof);
+  });
+});

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -1,0 +1,58 @@
+export const ErrMissingVersion = new TypeError("evidence version is missing");
+export const ErrMissingBackend = new TypeError("evidence backend is missing");
+export const ErrMissingProvider = new TypeError("evidence provider is missing");
+export const ErrMissingProof = new TypeError("evidence proof is missing");
+
+/**
+ * Evidences can be used to externally verify a link's existence at a given
+ * moment in time.
+ * An evidence can be a proof of inclusion in a public blockchain, a timestamp
+ * signed by a trusted authority or anything that you trust to provide an
+ * immutable ordering of your process' steps.
+ */
+export class Evidence {
+  /** Evidence version. Useful to correctly deserialize proof bytes. */
+  public readonly version: string;
+  /** Identifier of the evidence type. */
+  public readonly backend: string;
+  /** Instance of the backend used. */
+  public readonly provider: string;
+  /** Serialized proof. */
+  public readonly proof: Uint8Array;
+
+  constructor(
+    version: string,
+    backend: string,
+    provider: string,
+    proof: Uint8Array
+  ) {
+    this.version = version;
+    this.backend = backend;
+    this.provider = provider;
+    this.proof = proof;
+
+    this.validate();
+  }
+
+  /**
+   * Validate that the evidence is well-formed.
+   * The proof is opaque bytes so it isn't validated here.
+   */
+  public validate(): void {
+    if (!this.version) {
+      throw ErrMissingVersion;
+    }
+
+    if (!this.backend) {
+      throw ErrMissingBackend;
+    }
+
+    if (!this.provider) {
+      throw ErrMissingProvider;
+    }
+
+    if (!this.proof || this.proof.length === 0) {
+      throw ErrMissingProof;
+    }
+  }
+}

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -2,6 +2,9 @@ export const ErrMissingVersion = new TypeError("evidence version is missing");
 export const ErrMissingBackend = new TypeError("evidence backend is missing");
 export const ErrMissingProvider = new TypeError("evidence provider is missing");
 export const ErrMissingProof = new TypeError("evidence proof is missing");
+export const ErrDuplicateEvidence = new TypeError(
+  "evidence already exists for the given backend and provider"
+);
 
 /**
  * Evidences can be used to externally verify a link's existence at a given
@@ -12,13 +15,13 @@ export const ErrMissingProof = new TypeError("evidence proof is missing");
  */
 export class Evidence {
   /** Evidence version. Useful to correctly deserialize proof bytes. */
-  public readonly version: string;
+  public version: string;
   /** Identifier of the evidence type. */
-  public readonly backend: string;
+  public backend: string;
   /** Instance of the backend used. */
-  public readonly provider: string;
+  public provider: string;
   /** Serialized proof. */
-  public readonly proof: Uint8Array;
+  public proof: Uint8Array;
 
   constructor(
     version: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+import { deserialize as deserializeLink, Link } from "./link";
+import { LinkBuilder } from "./link_builder";
+import { Process } from "./process";
+import { deserialize as deserializeSegment, Segment } from "./segment";
+
+export {
+  LinkBuilder,
+  Link,
+  Process,
+  Segment,
+  deserializeLink,
+  deserializeSegment
+};

--- a/src/link.spec.ts
+++ b/src/link.spec.ts
@@ -11,6 +11,7 @@ import {
   LinkMeta as PbLinkMeta,
   Process as PbProcess
 } from "./proto/chainscript_pb";
+import { LinkReference } from "./ref";
 
 /**
  * Create a valid link.
@@ -51,6 +52,7 @@ describe("link", () => {
     expect(() => link.prevLinkHash()).toThrowError(ErrLinkMetaMissing);
     expect(() => link.priority()).toThrowError(ErrLinkMetaMissing);
     expect(() => link.process()).toThrowError(ErrLinkMetaMissing);
+    expect(() => link.refs()).toThrowError(ErrLinkMetaMissing);
     expect(() => link.step()).toThrowError(ErrLinkMetaMissing);
     expect(() => link.tags()).toThrowError(ErrLinkMetaMissing);
   });
@@ -230,6 +232,18 @@ describe("link", () => {
       expect(link2.process().name).toEqual("p1");
       expect(link2.tags()).toEqual(["tag1", "tag2"]);
       expect(link2.version()).toEqual(link.version());
+    });
+
+    it("with references", () => {
+      const ref1 = new LinkReference(Uint8Array.from([24]), "p1");
+      const ref2 = new LinkReference(Uint8Array.from([42]), "p2");
+      const link = new LinkBuilder("p1", "m1").withRefs([ref1, ref2]).build();
+
+      const serialized = link.serialize();
+      const link2 = deserialize(serialized);
+
+      expect(link2.hash()).toEqual(link.hash());
+      expect(link2.refs()).toEqual([ref1, ref2]);
     });
   });
 });

--- a/src/link.ts
+++ b/src/link.ts
@@ -7,6 +7,7 @@ import {
   LinkMeta as PbLinkMeta,
   Segment as PbSegment
 } from "./proto/chainscript_pb";
+import { LinkReference } from "./ref";
 import { Segment } from "./segment";
 
 export const ErrLinkMetaMissing = new TypeError("link meta is missing");
@@ -174,6 +175,22 @@ export class Link {
     }
 
     return new Process(process.getName(), process.getState());
+  }
+
+  /**
+   * A link can contain references to other links.
+   * @returns referenced links.
+   */
+  public refs(): LinkReference[] {
+    const meta = this.link.getMeta();
+    if (!meta) {
+      throw ErrLinkMetaMissing;
+    }
+
+    const pbRefs = meta.getRefsList();
+    return pbRefs.map(
+      ref => new LinkReference(ref.getLinkHash_asU8(), ref.getProcess())
+    );
   }
 
   /**

--- a/src/ref.spec.ts
+++ b/src/ref.spec.ts
@@ -1,0 +1,21 @@
+import { ErrMissingLinkHash, ErrMissingProcess, LinkReference } from "./ref";
+
+describe("link reference", () => {
+  it("rejects missing process", () => {
+    expect(() => new LinkReference(Uint8Array.from([42]), "")).toThrowError(
+      ErrMissingProcess
+    );
+  });
+
+  it("rejects missing link hash", () => {
+    expect(() => new LinkReference(new Uint8Array(0), "p")).toThrowError(
+      ErrMissingLinkHash
+    );
+  });
+
+  it("creates a valid reference", () => {
+    const ref = new LinkReference(Uint8Array.from([42]), "p");
+    expect(ref.process).toEqual("p");
+    expect(ref.linkHash).toEqual(Uint8Array.from([42]));
+  });
+});

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,0 +1,23 @@
+export const ErrMissingProcess = new TypeError("process is missing");
+export const ErrMissingLinkHash = new TypeError("link hash is missing");
+
+/**
+ * A reference to a link that can be in another process.
+ */
+export class LinkReference {
+  public linkHash: Uint8Array;
+  public process: string;
+
+  constructor(linkHash: Uint8Array, process: string) {
+    if (!process) {
+      throw ErrMissingProcess;
+    }
+
+    if (!linkHash || linkHash.length === 0) {
+      throw ErrMissingLinkHash;
+    }
+
+    this.linkHash = linkHash;
+    this.process = process;
+  }
+}

--- a/src/segment.spec.ts
+++ b/src/segment.spec.ts
@@ -1,3 +1,11 @@
+import {
+  ErrDuplicateEvidence,
+  ErrMissingBackend,
+  ErrMissingProof,
+  ErrMissingProvider,
+  ErrMissingVersion,
+  Evidence
+} from "./evidence";
 import { ErrUnknownLinkVersion } from "./link";
 import { LinkBuilder } from "./link_builder";
 import {
@@ -51,10 +59,99 @@ describe("segment", () => {
       .build()
       .segmentify();
 
+    const btcEvidence = new Evidence(
+      "0.1.0",
+      "bitcoin",
+      "testnet",
+      Uint8Array.from([42])
+    );
+    segment.addEvidence(btcEvidence);
+
     const serialized = segment.serialize();
     const segment2 = deserialize(serialized);
 
     expect(segment2.linkHash()).toEqual(segment.linkHash());
     expect(segment2.linkHash()).toEqual(segment.link().hash());
+    expect(segment2.evidences()).toHaveLength(1);
+    expect(segment2.evidences()[0]).toEqual(btcEvidence);
+  });
+
+  describe("evidences", () => {
+    function createEvidence(): Evidence {
+      return new Evidence("0.1.0", "bitcoin", "testnet", Uint8Array.from([42]));
+    }
+
+    it("rejects missing version", () => {
+      const e = createEvidence();
+      e.version = "";
+
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      expect(() => segment.addEvidence(e)).toThrowError(ErrMissingVersion);
+    });
+
+    it("rejects missing backend", () => {
+      const e = createEvidence();
+      e.backend = "";
+
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      expect(() => segment.addEvidence(e)).toThrowError(ErrMissingBackend);
+    });
+
+    it("rejects missing provider", () => {
+      const e = createEvidence();
+      e.provider = "";
+
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      expect(() => segment.addEvidence(e)).toThrowError(ErrMissingProvider);
+    });
+
+    it("rejects missing proof", () => {
+      const e = createEvidence();
+      e.proof = new Uint8Array(0);
+
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      expect(() => segment.addEvidence(e)).toThrowError(ErrMissingProof);
+    });
+
+    it("rejects duplicate evidence", () => {
+      const e = createEvidence();
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      segment.addEvidence(e);
+      expect(() => segment.addEvidence(e)).toThrowError(ErrDuplicateEvidence);
+    });
+
+    it("gets valid evidence", () => {
+      const e = createEvidence();
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      segment.addEvidence(e);
+
+      expect(segment.getEvidence(e.backend, e.provider)).toEqual(e);
+    });
+
+    it("gets no result", () => {
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      expect(segment.getEvidence("bitcoin", "testnet")).toBeNull();
+    });
+
+    it("finds valid evidences", () => {
+      const e1 = createEvidence();
+      const e2 = createEvidence();
+      e2.backend = "ethereum";
+
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      segment.addEvidence(e1);
+      segment.addEvidence(e2);
+
+      expect(segment.findEvidences("ethereum")).toEqual([e2]);
+      expect(segment.evidences()).toEqual([e1, e2]);
+    });
+
+    it("finds no result", () => {
+      const e = createEvidence();
+      const segment = new LinkBuilder("p", "m").build().segmentify();
+      segment.addEvidence(e);
+
+      expect(segment.findEvidences("ethereum")).toHaveLength(0);
+    });
   });
 });

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,5 +1,7 @@
+import { ErrDuplicateEvidence, Evidence } from "./evidence";
 import { Link } from "./link";
 import {
+  Evidence as PbEvidence,
   Link as PbLink,
   Segment as PbSegment,
   SegmentMeta as PbSegmentMeta
@@ -41,6 +43,90 @@ export class Segment {
 
     const link = new Link(pbLink);
     meta.setLinkHash(link.hash());
+  }
+
+  /**
+   * The segment can be enriched with evidence that the link was saved
+   * immutably somewhere.
+   * @param e evidence.
+   */
+  public addEvidence(e: Evidence): void {
+    e.validate();
+
+    if (this.getEvidence(e.backend, e.provider)) {
+      throw ErrDuplicateEvidence;
+    }
+
+    const pbEvidence = new PbEvidence();
+    pbEvidence.setVersion(e.version);
+    pbEvidence.setBackend(e.backend);
+    pbEvidence.setProvider(e.provider);
+    pbEvidence.setProof(e.proof);
+
+    (this.pbSegment.getMeta() as PbSegmentMeta).addEvidences(pbEvidence);
+  }
+
+  /**
+   * Return all the evidences in this segment.
+   * @returns evidences.
+   */
+  public evidences(): Evidence[] {
+    return (this.pbSegment.getMeta() as PbSegmentMeta)
+      .getEvidencesList()
+      .map(
+        e =>
+          new Evidence(
+            e.getVersion(),
+            e.getBackend(),
+            e.getProvider(),
+            e.getProof_asU8()
+          )
+      );
+  }
+
+  /**
+   * Return all the evidences of a specific backend.
+   * @param backend of the expected evidences.
+   * @returns evidences.
+   */
+  public findEvidences(backend: string): Evidence[] {
+    return (this.pbSegment.getMeta() as PbSegmentMeta)
+      .getEvidencesList()
+      .filter(e => e.getBackend() === backend)
+      .map(
+        e =>
+          new Evidence(
+            e.getVersion(),
+            e.getBackend(),
+            e.getProvider(),
+            e.getProof_asU8()
+          )
+      );
+  }
+
+  /**
+   * Retrieve the evidence for the given backend and provider (if one exists).
+   * @param backend evidence backend.
+   * @param provider evidence backend instance.
+   * @returns the evidence or null.
+   */
+  public getEvidence(backend: string, provider: string): Evidence | null {
+    const evidences = (this.pbSegment.getMeta() as PbSegmentMeta).getEvidencesList();
+    for (const current of evidences) {
+      if (
+        current.getBackend() === backend &&
+        current.getProvider() === provider
+      ) {
+        return new Evidence(
+          current.getVersion(),
+          current.getBackend(),
+          current.getProvider(),
+          current.getProof_asU8()
+        );
+      }
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
Just like go-chainscript, we let the format of the evidence proof be handled outside this package.
It allows clients to define arbitrary versioned evidences and we only act as a data storage.
Evidence proofs could be serialized via protobuf, json or anything else depending on the application's requirements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-chainscript/8)
<!-- Reviewable:end -->
