### PR TITLE
docker: expose test CLI as a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+samples
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Expose the compatibility test CLI.
 # The CLI offers the following features:
-#   * Generate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/samples stratumn/js-chainscript:latest generate ./samples/js-samples.json
-#   * Validate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/samples stratumn/js-chainscript:latest validate ./samples/go-samples.json
+#   * Generate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/samples stratumn/js-chainscript:latest generate /samples/js-samples.json
+#   * Validate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/samples stratumn/js-chainscript:latest validate /samples/go-samples.json
 
 FROM node:alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Expose the compatibility test CLI.
+# The CLI offers the following features:
+#   * Generate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/chainscript/samples stratumn/js-chainscript:latest generate ./samples/js-samples.json
+#   * Validate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/chainscript/samples stratumn/js-chainscript:latest validate ./samples/go-samples.json
+
+FROM node:alpine
+
+RUN mkdir /chainscript
+ADD . /chainscript
+
+WORKDIR /chainscript
+RUN npm i
+RUN npm run build
+
+ENTRYPOINT [ "node", "./lib/cli/cli.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Expose the compatibility test CLI.
 # The CLI offers the following features:
-#   * Generate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/chainscript/samples stratumn/js-chainscript:latest generate ./samples/js-samples.json
-#   * Validate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/chainscript/samples stratumn/js-chainscript:latest validate ./samples/go-samples.json
+#   * Generate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/samples stratumn/js-chainscript:latest generate ./samples/js-samples.json
+#   * Validate test data: docker run --mount type=bind,source="$(pwd)"/samples,target=/samples stratumn/js-chainscript:latest validate ./samples/go-samples.json
 
 FROM node:alpine
 
+RUN mkdir /samples
 RUN mkdir /chainscript
 ADD . /chainscript
 


### PR DESCRIPTION
The docker images will be built after each push to master and will be used by the chainscript nightly job to verify compatibility between all official chainscript implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-chainscript/15)
<!-- Reviewable:end -->
