### PR TITLE
linkhash: uint8array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,20 @@
 import * as constants from "./const";
 import * as errors from "./errors";
 import { Evidence } from "./evidence";
-import { deserialize as deserializeLink,  fromObject as fromLinkObject, Link } from "./link";
+import {
+  deserialize as deserializeLink,
+  fromObject as fromLinkObject,
+  Link
+} from "./link";
 import { LinkBuilder } from "./link_builder";
 import { Process } from "./process";
 import { LinkReference } from "./ref";
-import { deserialize as deserializeSegment, fromObject as fromSegmentObject, Segment } from "./segment";
-import { Signature } from "./signature";
+import {
+  deserialize as deserializeSegment,
+  fromObject as fromSegmentObject,
+  Segment
+} from "./segment";
+import { sign, Signature, signLink } from "./signature";
 
 export {
   constants,
@@ -35,5 +43,7 @@ export {
   LinkReference,
   Process,
   Segment,
-  Signature
+  sign,
+  Signature,
+  signLink
 };

--- a/src/link.spec.ts
+++ b/src/link.spec.ts
@@ -354,6 +354,20 @@ describe("link", () => {
 
       expect(l2.data().hello).toBe("world!");
     });
+
+    it("converts prevLinkHash to uint8array", () => {
+      const prevLink = new LinkBuilder("p1", "m1").build();
+      const prevSegment = prevLink.segmentify();
+
+      const link = new LinkBuilder("p1", "m1")
+        .withParent(prevSegment.linkHash())
+        .build();
+
+      const parsedLink = fromObject(link.toObject());
+
+      expect(parsedLink.prevLinkHash()).toEqual(prevSegment.linkHash());
+      expect(parsedLink.prevLinkHash()).toEqual(prevLink.hash());
+    });
   });
 
   describe("addSignature", () => {

--- a/src/link.ts
+++ b/src/link.ts
@@ -177,7 +177,13 @@ export class Link {
       throw errors.ErrLinkMetaMissing;
     }
 
-    return meta.prevLinkHash || new Uint8Array(0);
+    if (!meta.prevLinkHash) {
+      return new Uint8Array(0);
+    }
+
+    // We re-wrap inside a Uint8Array because it might have become a Buffer if
+    // converted from a plain Javascript object.
+    return new Uint8Array(meta.prevLinkHash);
   }
 
   /**

--- a/src/segment.spec.ts
+++ b/src/segment.spec.ts
@@ -236,5 +236,12 @@ describe("segment", () => {
 
       expect(s2).toEqual(s1);
     });
+
+    it("converts link hash to uint8array", () => {
+      const segment = new LinkBuilder("p1", "m1").build().segmentify();
+      const parsedSegment = fromObject(segment.toObject());
+
+      expect(parsedSegment.linkHash()).toEqual(segment.linkHash());
+    });
   });
 });


### PR DESCRIPTION
Using toObject and fromObject loses the Uint8Array type.
We always wrap to make sure the client receives a Uint8Array.
To compare linkHashes, the client should do: l1.prevLinkHash().buffer === l2.prevLinkHash().buffer
And this works in both browser and node.
For some reason === doesn't work directly on Uint8Array (at least without babel-ing it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-chainscript/26)
<!-- Reviewable:end -->
