### PR TITLE
evidence: add toObject and fromObject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratumn/js-chainscript",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratumn/js-chainscript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official JavaScript implementation of https://github.com/stratumn/chainscript.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/evidence.spec.ts
+++ b/src/evidence.spec.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as errors from "./errors";
-import { Evidence, fromProto } from "./evidence";
+import { Evidence, fromObject, fromProto } from "./evidence";
 import { stratumn } from "./proto/chainscript_pb";
 
 describe("evidence", () => {
@@ -61,5 +61,43 @@ describe("evidence", () => {
     expect(() => fromProto(new stratumn.chainscript.Evidence())).toThrowError(
       errors.ErrEvidenceVersionMissing
     );
+  });
+
+  it("converts bytes to base64", () => {
+    const e = new Evidence(
+      "1.0.0",
+      "btc",
+      "mainnet",
+      Uint8Array.from([42, 24])
+    );
+
+    const plainObj = e.toObject({ bytes: String });
+    expect(plainObj).toEqual({
+      backend: "btc",
+      proof: "Khg=",
+      provider: "mainnet",
+      version: "1.0.0"
+    });
+
+    expect(fromObject(plainObj)).toEqual(e);
+  });
+
+  it("converts to object and keeps bytes", () => {
+    const e = new Evidence(
+      "1.0.0",
+      "btc",
+      "mainnet",
+      Uint8Array.from([42, 24])
+    );
+
+    const plainObj = e.toObject();
+    expect(plainObj).toEqual({
+      backend: "btc",
+      proof: Uint8Array.from([42, 24]),
+      provider: "mainnet",
+      version: "1.0.0"
+    });
+
+    expect(fromObject(plainObj)).toEqual(e);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
 
 import * as constants from "./const";
 import * as errors from "./errors";
-import { Evidence } from "./evidence";
+import { Evidence, fromObject as fromEvidenceObject } from "./evidence";
 import {
   deserialize as deserializeLink,
   fromObject as fromLinkObject,
@@ -39,6 +39,7 @@ export {
   constants,
   deserializeLink,
   deserializeSegment,
+  fromEvidenceObject,
   fromLinkObject,
   fromSegmentObject,
   fromSignatureObject,

--- a/src/link.ts
+++ b/src/link.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as b64 from "base64-js";
 import { parse, stringify } from "@stratumn/canonicaljson";
+import * as b64 from "base64-js";
 import sha256 from "fast-sha256";
 import { search } from "jmespath";
 import { Base64 } from "js-base64";


### PR DESCRIPTION
This utility is useful for the clients that use JSON and want to manipulate evidences to and from a store.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-chainscript/34)
<!-- Reviewable:end -->
