### PR TITLE
Update: Deserialize evidence

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.singleQuote": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3493,7 +3493,8 @@
     "merge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge-stream": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratumn/js-chainscript",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Official JavaScript implementation of https://github.com/stratumn/chainscript.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/evidence.spec.ts
+++ b/src/evidence.spec.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as errors from "./errors";
-import { Evidence, fromObject, fromProto } from "./evidence";
+import { deserialize, Evidence, fromObject, fromProto } from "./evidence";
 import { stratumn } from "./proto/chainscript_pb";
 
 describe("evidence", () => {
@@ -99,5 +99,20 @@ describe("evidence", () => {
     });
 
     expect(fromObject(plainObj)).toEqual(e);
+  });
+
+  it("serializes and deserializes", () => {
+    const e = new Evidence(
+      "1.0.0",
+      "btc",
+      "mainnet",
+      Uint8Array.from([42, 24])
+    );
+    const bytes = e.serialize();
+    const d = deserialize(bytes);
+    expect(Uint8Array.from(d.proof)).toEqual(e.proof);
+    expect(d.backend).toEqual(e.backend);
+    expect(d.provider).toEqual(e.provider);
+    expect(d.version).toEqual(e.version);
   });
 });

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -31,6 +31,16 @@ export function fromProto(e: stratumn.chainscript.IEvidence): Evidence {
 }
 
 /**
+ * Deserialize an evidence.
+ * @param evidenceBytes encoded bytes.
+ * @returns the deserialized evidence.
+ */
+export function deserialize(evidenceBytes: Uint8Array): Evidence {
+  const pbEvidence = stratumn.chainscript.Evidence.decode(evidenceBytes);
+  return fromProto(pbEvidence);
+}
+
+/**
  * Convert a plain object to an evidence.
  * @param e plain object.
  */
@@ -98,6 +108,15 @@ export class Evidence {
     if (!this.proof || this.proof.length === 0) {
       throw errors.ErrEvidenceProofMissing;
     }
+  }
+
+  /**
+   * Serialize the evidence.
+   * @returns evidence bytes.
+   */
+  public serialize(): Uint8Array {
+    const e = stratumn.chainscript.Evidence.fromObject(this);
+    return stratumn.chainscript.Evidence.encode(e).finish();
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,43 +14,29 @@
 
 import * as constants from "./const";
 import * as errors from "./errors";
-import { Evidence, fromObject as fromEvidenceObject } from "./evidence";
-import {
+export {
+  deserialize as deserializeEvidence,
+  Evidence,
+  fromObject as fromEvidenceObject
+} from "./evidence";
+export {
   deserialize as deserializeLink,
   fromObject as fromLinkObject,
   Link
 } from "./link";
-import { LinkBuilder } from "./link_builder";
-import { Process } from "./process";
-import { LinkReference } from "./ref";
-import {
+export { LinkBuilder } from "./link_builder";
+export { Process } from "./process";
+export { LinkReference } from "./ref";
+export {
   deserialize as deserializeSegment,
   fromObject as fromSegmentObject,
   Segment
 } from "./segment";
-import {
+export {
   fromObject as fromSignatureObject,
   sign,
   Signature,
   signLink
 } from "./signature";
 
-export {
-  constants,
-  deserializeLink,
-  deserializeSegment,
-  fromEvidenceObject,
-  fromLinkObject,
-  fromSegmentObject,
-  fromSignatureObject,
-  errors,
-  Evidence,
-  Link,
-  LinkBuilder,
-  LinkReference,
-  Process,
-  Segment,
-  sign,
-  Signature,
-  signLink
-};
+export { constants, errors };


### PR DESCRIPTION
The Evidence class was missing a serialize / deserialize. I took the opportunity to add a vscode settings to fix the double quote issue and change the main `index.ts` way of exporting stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-chainscript/39)
<!-- Reviewable:end -->
